### PR TITLE
Add menu and sample exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Ce dépôt contient un programme `exercices` permettant d'exécuter différents exercices.
 
-Pour l'instant, un seul exercice est disponible : `anglais_hello_world` qui affiche `hello world!`.
+Le menu propose plusieurs exercices :
+- `anglais_hello_world` affiche `hello world!`
+- `math_addition` affiche `1+1=2`
+- `hist_test` affiche `La préhistoire c'est ce qu'il y a avant l'histoire.`
 
 ## Exécuter
 

--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -1,11 +1,27 @@
 """Point d'entrée pour le programme exercices."""
 
-from . import anglais_hello_world
+from . import anglais_hello_world, hist_test, math_addition
+
+EXERCICES = [
+    ("anglais_hello_world", anglais_hello_world.main),
+    ("math_addition", math_addition.main),
+    ("hist_test", hist_test.main),
+]
 
 
 def main():
-    """Lance l'exercice anglais hello world."""
-    anglais_hello_world.main()
+    """Affiche un menu et lance l'exercice choisi."""
+    print("Choisissez un exercice :")
+    for index, (name, _) in enumerate(EXERCICES, start=1):
+        print(f"{index}. {name}")
+    choice = input("Votre choix : ")
+    try:
+        index = int(choice) - 1
+        _, func = EXERCICES[index]
+    except (ValueError, IndexError):
+        print("Choix invalide")
+        return
+    func()
 
 
 if __name__ == "__main__":

--- a/exercices/hist_test.py
+++ b/exercices/hist_test.py
@@ -1,0 +1,3 @@
+def main():
+    """Affiche une phrase d'histoire."""
+    print("La préhistoire c'est ce qu'il y a avant l'histoire.")

--- a/exercices/math_addition.py
+++ b/exercices/math_addition.py
@@ -1,0 +1,3 @@
+def main():
+    """Affiche un exemple de calcul d'addition."""
+    print("1+1=2")


### PR DESCRIPTION
## Summary
- Implement interactive menu to run exercises
- Add sample math and history exercises
- Document available exercises in README

## Testing
- `python -m exercices <<'EOF'
1
EOF`
- `python -m exercices <<'EOF'
2
EOF`
- `python -m exercices <<'EOF'
3
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68bd8fd37a988323bb053e43010b3d38