### PR TITLE
Ajoute leçon et quiz sur les changements d'état

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Le menu propose plusieurs exercices :
 - `anglais_hello_world` affiche `hello world!`
 - `math_addition` affiche `1+1=2`
 - `hist_test` affiche `La préhistoire c'est ce qu'il y a avant l'histoire.`
+- `physique_changements_etats` propose une leçon et un quiz sur les changements d'état de la matière.
 
 ## Exécuter
 

--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -1,11 +1,12 @@
 """Point d'entrée pour le programme exercices."""
 
-from . import anglais_hello_world, hist_test, math_addition
+from . import anglais_hello_world, hist_test, math_addition, physique_changements_etats
 
 EXERCICES = [
     ("anglais_hello_world", anglais_hello_world.main),
     ("math_addition", math_addition.main),
     ("hist_test", hist_test.main),
+    ("physique_changements_etats", physique_changements_etats.main),
 ]
 
 

--- a/exercices/physique_changements_etats.py
+++ b/exercices/physique_changements_etats.py
@@ -1,0 +1,110 @@
+"""Leçon et quiz sur les changements d'état de la matière."""
+
+
+def main():
+    """Présente la leçon puis un quiz corrigé."""
+    # Leçon introductive
+    print("Changements d'état de la matière\n")
+    print("1. Fusion : passage de l'état solide à l'état liquide. \n"
+          "   Exemple : la glace qui devient de l'eau." )
+    print("2. Solidification : passage du liquide au solide. \n"
+          "   Exemple : l'eau qui gèle dans le congélateur.")
+    print("3. Vaporisation : passage du liquide au gaz. \n"
+          "   Exemple : l'eau qui bout devient de la vapeur.")
+    print("4. Condensation : passage du gaz au liquide. \n"
+          "   Exemple : la vapeur d'eau qui forme des gouttes sur une vitre froide.")
+    print("5. Sublimation : passage direct du solide au gaz sans devenir liquide. \n"
+          "   Exemple : la glace sèche qui disparaît en fumée.")
+    print("6. Condensation solide : passage direct du gaz au solide. \n"
+          "   Exemple : le givre qui se forme sur une fenêtre en hiver.\n")
+
+    # Définition des questions du quiz
+    questions = [
+        {
+            "question": "Le passage de l'état solide à l'état liquide s'appelle...",
+            "choices": ["la fusion", "la solidification", "la vaporisation"],
+            "answer": 0,
+        },
+        {
+            "question": "Le passage de l'état liquide à l'état solide s'appelle...",
+            "choices": ["la fusion", "la condensation", "la solidification"],
+            "answer": 2,
+        },
+        {
+            "question": "Le passage de l'état liquide à l'état gazeux s'appelle...",
+            "choices": ["la sublimation", "la vaporisation", "la condensation"],
+            "answer": 1,
+        },
+        {
+            "question": "Le passage de l'état gazeux à l'état liquide s'appelle...",
+            "choices": ["la condensation", "la solidification", "la fusion"],
+            "answer": 0,
+        },
+        {
+            "question": "Le passage direct du solide au gaz s'appelle...",
+            "choices": ["la condensation", "la vaporisation", "la sublimation"],
+            "answer": 2,
+        },
+        {
+            "question": "Le passage direct du gaz au solide s'appelle...",
+            "choices": ["la fusion", "la condensation solide", "la sublimation"],
+            "answer": 1,
+        },
+        {
+            "question": "La glace qui fond dans un verre d'eau est un exemple de...",
+            "choices": ["fusion", "condensation solide", "vaporisation"],
+            "answer": 0,
+        },
+        {
+            "question": "La buée qui se forme sur un miroir après une douche est due à...",
+            "choices": ["la condensation", "la sublimation", "la fusion"],
+            "answer": 0,
+        },
+        {
+            "question": "Quand on met de l'eau au congélateur, l'eau subit...",
+            "choices": ["la vaporisation", "la solidification", "la sublimation"],
+            "answer": 1,
+        },
+        {
+            "question": "La formation de givre sur un pare-brise par temps froid est un exemple de...",
+            "choices": ["condensation solide", "vaporisation", "fusion", "condensation"],
+            "answer": 0,
+        },
+    ]
+
+    # Réponses de l'élève pour l'exemple (0 -> premier choix, 1 -> deuxième, ...)
+    student_answers = [0, 2, 1, 2, 2, 1, 0, 0, 0, 0]
+
+    print("Quiz : réponds mentalement à chaque question.")
+    for i, q in enumerate(questions, start=1):
+        print(f"\nQuestion {i}: {q['question']}")
+        for j, choice in enumerate(q["choices"], start=1):
+            print(f"  {j}. {choice}")
+
+    print("\nCorrection :")
+    score = 0
+    for i, q in enumerate(questions, start=1):
+        student = student_answers[i - 1]
+        correct = q["answer"]
+        student_text = q["choices"][student]
+        correct_text = q["choices"][correct]
+        if student == correct:
+            print(f"Question {i}: {student + 1}. {student_text} ✔️")
+            score += 1
+        else:
+            print(
+                f"Question {i}: {student + 1}. {student_text} ❌ (bonne réponse : {correct + 1}. {correct_text})"
+            )
+
+    total = len(questions)
+    print(f"\nScore final : {score}/{total}")
+    if score == total:
+        print("Excellent travail ! Tu maîtrises parfaitement les changements d'état.")
+    elif score >= total / 2:
+        print("Bravo ! Continue à réviser pour progresser encore.")
+    else:
+        print("Courage, relis la leçon et essaie à nouveau !")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Ajout d'un module `physique_changements_etats` proposant une leçon simple sur les changements d'état de la matière et un quiz de 10 questions corrigé.
- Intégration de l'exercice au menu principal.
- Mise à jour du README pour référencer ce nouvel exercice.

## Testing
- `python -m exercices <<'EOF'
4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68bd913c8b88832381a19fe1dc872541