### PR TITLE
feat: scrollable lessons and colorful physics quiz

### DIFF
--- a/exercices/anglais_hello_world.py
+++ b/exercices/anglais_hello_world.py
@@ -1,7 +1,13 @@
 """Module anglais_hello_world - affiche Hello World"""
 
-def main():
-    print("hello world!")
+from .utils import scroll_text
+
+
+def main() -> None:
+    """Affiche le traditionnel message d'accueil."""
+
+    scroll_text("hello world!\n")
+
 
 if __name__ == "__main__":
     main()

--- a/exercices/hist_test.py
+++ b/exercices/hist_test.py
@@ -1,3 +1,7 @@
-def main():
+from .utils import scroll_text
+
+
+def main() -> None:
     """Affiche une phrase d'histoire."""
-    print("La préhistoire c'est ce qu'il y a avant l'histoire.")
+
+    scroll_text("La préhistoire c'est ce qu'il y a avant l'histoire.\n")

--- a/exercices/math_addition.py
+++ b/exercices/math_addition.py
@@ -1,3 +1,7 @@
-def main():
+from .utils import scroll_text
+
+
+def main() -> None:
     """Affiche un exemple de calcul d'addition."""
-    print("1+1=2")
+
+    scroll_text("1+1=2\n")

--- a/exercices/physique_changements_etats.py
+++ b/exercices/physique_changements_etats.py
@@ -1,22 +1,42 @@
 """Leçon et quiz sur les changements d'état de la matière."""
 
+from .utils import scroll_text, wait_for_letter
 
-def main():
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+CYAN = "\033[96m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def main() -> None:
     """Présente la leçon puis un quiz corrigé."""
-    # Leçon introductive
-    print("Changements d'état de la matière\n")
-    print("1. Fusion : passage de l'état solide à l'état liquide. \n"
-          "   Exemple : la glace qui devient de l'eau." )
-    print("2. Solidification : passage du liquide au solide. \n"
-          "   Exemple : l'eau qui gèle dans le congélateur.")
-    print("3. Vaporisation : passage du liquide au gaz. \n"
-          "   Exemple : l'eau qui bout devient de la vapeur.")
-    print("4. Condensation : passage du gaz au liquide. \n"
-          "   Exemple : la vapeur d'eau qui forme des gouttes sur une vitre froide.")
-    print("5. Sublimation : passage direct du solide au gaz sans devenir liquide. \n"
-          "   Exemple : la glace sèche qui disparaît en fumée.")
-    print("6. Condensation solide : passage direct du gaz au solide. \n"
-          "   Exemple : le givre qui se forme sur une fenêtre en hiver.\n")
+
+    lesson = f"""
+{CYAN}{BOLD}🌡️  Changements d'état de la matière  🌡️{RESET}
+
+1. ❄️  {BOLD}Fusion{RESET}            →  solide  →  liquide
+   Exemple : la glace qui devient de l'eau.
+
+2. 🧊  {BOLD}Solidification{RESET}    →  liquide  →  solide
+   Exemple : l'eau qui gèle dans le congélateur.
+
+3. 💧  {BOLD}Vaporisation{RESET}      →  liquide  →  gaz
+   Exemple : l'eau qui bout devient de la vapeur.
+
+4. ☁️  {BOLD}Condensation{RESET}      →  gaz     →  liquide
+   Exemple : la vapeur d'eau qui forme des gouttes sur une vitre froide.
+
+5. 🎈  {BOLD}Sublimation{RESET}       →  solide  →  gaz
+   Exemple : la glace sèche qui disparaît en fumée.
+
+6. ✨  {BOLD}Condensation solide{RESET} →  gaz     →  solide
+   Exemple : le givre qui se forme sur une fenêtre en hiver.
+"""
+
+    scroll_text(lesson)
+    wait_for_letter("q", "Tape 'q' pour passer au quiz : ")
 
     # Définition des questions du quiz
     questions = [
@@ -85,19 +105,19 @@ def main():
         correct = q["answer"]
         correct_text = q["choices"][correct]
         if student == correct:
-            print("Exact !")
+            print(f"{GREEN}Exact ! ✅{RESET}")
             score += 1
         else:
-            print(f"Non, la bonne réponse était {correct + 1}. {correct_text}")
+            print(f"{RED}Non, la bonne réponse était {correct + 1}. {correct_text} ❌{RESET}")
 
     total = len(questions)
-    print(f"\nScore final : {score}/{total}")
+    print(f"\n{BOLD}Score final : {score}/{total}{RESET}")
     if score == total:
-        print("Excellent travail ! Tu maîtrises parfaitement les changements d'état.")
+        print(f"{GREEN}Excellent travail ! Tu maîtrises parfaitement les changements d'état. 🥳{RESET}")
     elif score >= total / 2:
-        print("Bravo ! Continue à réviser pour progresser encore.")
+        print(f"{CYAN}Bravo ! Continue à réviser pour progresser encore. 👍{RESET}")
     else:
-        print("Courage, relis la leçon et essaie à nouveau !")
+        print(f"{RED}Courage, relis la leçon et essaie à nouveau ! 💪{RESET}")
 
 
 if __name__ == "__main__":

--- a/exercices/utils.py
+++ b/exercices/utils.py
@@ -1,0 +1,37 @@
+"""Small helpers used by the different lessons.
+
+This module centralises behaviour that is shared by several exercises,
+such as displaying long pieces of text in a scrollable box.
+"""
+
+from __future__ import annotations
+
+import pydoc
+
+
+def scroll_text(text: str) -> None:
+    """Display ``text`` inside a scrollable pager.
+
+    The user can navigate with the arrow keys when the content is longer
+    than the terminal size.  Execution returns once the user exits the
+    pager (usually by pressing ``q``).
+    """
+
+    pydoc.pager(text)
+
+
+def wait_for_letter(letter: str, prompt: str) -> None:
+    """Block until ``letter`` is typed by the user.
+
+    Parameters
+    ----------
+    letter:
+        The expected letter (case-insensitive).
+    prompt:
+        Message displayed to the user.
+    """
+
+    while True:
+        if input(prompt).strip().lower() == letter.lower():
+            break
+

--- a/exercices/utils.py
+++ b/exercices/utils.py
@@ -6,17 +6,15 @@ such as displaying long pieces of text in a scrollable box.
 
 from __future__ import annotations
 
-import os
-import subprocess
 import pydoc
 
 
 def scroll_text(text: str) -> None:
     """Display ``text`` inside a scrollable pager.
 
-    The function prefers the ``less`` pager so that ANSI colours and
-    Unicode characters are rendered correctly.  If ``less`` is not
-    available, it falls back to :func:`pydoc.pager`.
+    The implementation relies solely on :func:`pydoc.pager` so that the
+    behaviour is consistent across platforms.  If a pager cannot be
+    launched, the text is simply printed to the terminal.
 
     Parameters
     ----------
@@ -24,14 +22,10 @@ def scroll_text(text: str) -> None:
         The content to display.
     """
 
-    env = {**os.environ, "LESSCHARSET": "utf-8"}
     try:
-        # ``-R`` preserves raw control characters (colours).
-        subprocess.run(
-            ["less", "-R"], input=text.encode("utf-8"), check=True, env=env
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError):
         pydoc.pager(text)
+    except Exception:
+        print(text)
 
 
 def wait_for_letter(letter: str, prompt: str) -> None:

--- a/exercices/utils.py
+++ b/exercices/utils.py
@@ -6,6 +6,7 @@ such as displaying long pieces of text in a scrollable box.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import pydoc
 
@@ -23,9 +24,12 @@ def scroll_text(text: str) -> None:
         The content to display.
     """
 
+    env = {**os.environ, "LESSCHARSET": "utf-8"}
     try:
         # ``-R`` preserves raw control characters (colours).
-        subprocess.run(["less", "-R"], input=text, text=True, check=True)
+        subprocess.run(
+            ["less", "-R"], input=text.encode("utf-8"), check=True, env=env
+        )
     except (FileNotFoundError, subprocess.CalledProcessError):
         pydoc.pager(text)
 

--- a/exercices/utils.py
+++ b/exercices/utils.py
@@ -6,18 +6,28 @@ such as displaying long pieces of text in a scrollable box.
 
 from __future__ import annotations
 
+import subprocess
 import pydoc
 
 
 def scroll_text(text: str) -> None:
     """Display ``text`` inside a scrollable pager.
 
-    The user can navigate with the arrow keys when the content is longer
-    than the terminal size.  Execution returns once the user exits the
-    pager (usually by pressing ``q``).
+    The function prefers the ``less`` pager so that ANSI colours and
+    Unicode characters are rendered correctly.  If ``less`` is not
+    available, it falls back to :func:`pydoc.pager`.
+
+    Parameters
+    ----------
+    text:
+        The content to display.
     """
 
-    pydoc.pager(text)
+    try:
+        # ``-R`` preserves raw control characters (colours).
+        subprocess.run(["less", "-R"], input=text, text=True, check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pydoc.pager(text)
 
 
 def wait_for_letter(letter: str, prompt: str) -> None:


### PR DESCRIPTION
## Summary
- add utility helpers to show lessons in scrollable pagers
- render all lessons through the pager
- enhance physics lesson with colored text and quiz feedback

## Testing
- `python -m py_compile exercices/*.py`
- `python -m exercices <<'EOF'
0
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68bd94cad6688323b199a31a97dd1cc4