### PR TITLE
feat: show quit hint in pager

### DIFF
--- a/exercices/physique_changements_etats.py
+++ b/exercices/physique_changements_etats.py
@@ -1,6 +1,6 @@
 """Leçon et quiz sur les changements d'état de la matière."""
 
-from .utils import scroll_text, wait_for_letter
+from .utils import scroll_text
 
 
 GREEN = "\033[92m"
@@ -35,8 +35,7 @@ def main() -> None:
    Exemple : le givre qui se forme sur une fenêtre en hiver.
 """
 
-    scroll_text(lesson)
-    wait_for_letter("q", "Tape 'q' pour passer au quiz : ")
+    scroll_text(lesson, hint="Tape 'q' pour passer au quiz")
 
     # Définition des questions du quiz
     questions = [


### PR DESCRIPTION
## Summary
- show exit hint in `scroll_text` so users always know to press `q`
- remove redundant wait-for-letter step before the quiz

## Testing
- `python -m py_compile exercices/utils.py exercices/physique_changements_etats.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda9109b5c8323b5cc10270a2bafe9