### PR TITLE
Add exercise logging and adaptive multiplication quiz

### DIFF
--- a/exercices/anglais_hello_world.py
+++ b/exercices/anglais_hello_world.py
@@ -1,12 +1,14 @@
 """Module anglais_hello_world - affiche Hello World"""
 
 from .utils import scroll_text
+from .logger import log_result
 
 
 def main() -> None:
     """Affiche le traditionnel message d'accueil."""
 
     scroll_text("hello world!\n")
+    log_result("anglais_hello_world", 100)
 
 
 if __name__ == "__main__":

--- a/exercices/hist_test.py
+++ b/exercices/hist_test.py
@@ -1,7 +1,9 @@
 from .utils import scroll_text
+from .logger import log_result
 
 
 def main() -> None:
     """Affiche une phrase d'histoire."""
 
     scroll_text("La préhistoire c'est ce qu'il y a avant l'histoire.\n")
+    log_result("hist_test", 100)

--- a/exercices/logger.py
+++ b/exercices/logger.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Simple logging utilities for exercises.
+
+Each entry records the UTC timestamp, the exercise name and the final
+score as a percentage.  Data is stored in JSON Lines format so it is easy
+to append and parse.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+LOG_FILE = Path(__file__).with_name("exercise_log.jsonl")
+
+
+def log_result(exercise: str, score: float | None) -> None:
+    """Append a result to the log file.
+
+    Parameters
+    ----------
+    exercise:
+        Name of the exercise.
+    score:
+        Final score as a percentage.  ``None`` may be used when the
+        concept of score does not apply.
+    """
+
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "exercise": exercise,
+        "score": score,
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def get_scores(exercise: str, limit: int | None = None) -> List[float]:
+    """Return past scores for ``exercise``.
+
+    Parameters
+    ----------
+    exercise:
+        Name of the exercise to filter in the log.
+    limit:
+        If provided, only the last ``limit`` scores are returned.
+    """
+
+    if not LOG_FILE.exists():
+        return []
+
+    scores: List[float] = []
+    with LOG_FILE.open("r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if data.get("exercise") == exercise and isinstance(data.get("score"), (int, float)):
+                scores.append(float(data["score"]))
+
+    if limit is not None:
+        scores = scores[-limit:]
+    return scores

--- a/exercices/math_tables_multiplication.py
+++ b/exercices/math_tables_multiplication.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 """Tables de multiplication avec quiz interactif."""
 
+import random
+
+from .logger import get_scores, log_result
 from .utils import show_lesson
 
-
-LETTERS = ["a", "b", "c"]
+LETTERS = ["a", "b", "c", "d", "e"]
 
 
 def multiplication_tables() -> str:
@@ -18,49 +22,83 @@ def multiplication_tables() -> str:
     return "\n".join(lines)
 
 
+def _generate_choices(n: int, m: int, hard_mode: bool) -> list[int]:
+    """Create answer choices for ``n × m`` respecting difficulty."""
+
+    correct = n * m
+    wrong: set[int] = set()
+
+    if hard_mode:
+        variations = [(n - 1, m), (n + 1, m), (n, m - 1), (n, m + 1)]
+        if random.random() < 0.5:
+            idx = random.randrange(len(variations))
+            variations[idx] = (n - 1, m + 1)
+        for a, b in variations:
+            product = a * b
+            if product != correct:
+                wrong.add(product)
+        while len(wrong) < 4:
+            candidate = correct + random.choice([-3, -2, -1, 1, 2, 3])
+            if candidate != correct:
+                wrong.add(candidate)
+    else:
+        while len(wrong) < 2:
+            a = random.randint(1, 5)
+            b = random.randint(1, 5)
+            if a + b > 3:
+                product = (n + a) * (m + b)
+                if product != correct:
+                    wrong.add(product)
+
+    choices = list(wrong) + [correct]
+    random.shuffle(choices)
+    return choices
+
+
+def _generate_question(hard_mode: bool) -> tuple[str, list[int], int]:
+    """Return a question, choices and index of the correct answer."""
+
+    if hard_mode:
+        n = random.randint(2, 9)
+        m = random.randint(2, 9)
+    else:
+        n = random.randint(1, 10)
+        m = random.randint(1, 10)
+    question = f"Combien font {n} × {m} ?"
+    choices = _generate_choices(n, m, hard_mode)
+    answer_index = choices.index(n * m)
+    return question, choices, answer_index
+
+
 def main() -> None:
     """Affiche les tables de multiplication puis un quiz."""
 
     show_lesson(multiplication_tables())
 
-    questions = [
-        {
-            "question": "Combien font 3 × 4 ?",
-            "choices": ["7", "12", "9"],
-            "answer": 1,
-        },
-        {
-            "question": "Combien font 5 × 6 ?",
-            "choices": ["11", "30", "28"],
-            "answer": 1,
-        },
-        {
-            "question": "Combien font 9 × 8 ?",
-            "choices": ["72", "81", "64"],
-            "answer": 0,
-        },
-    ]
+    previous = get_scores("math_tables_multiplication", limit=5)
+    hard_mode = bool(previous) and sum(previous) / len(previous) > 75
 
     print("Quiz : réponds en tapant la lettre de la bonne réponse.")
     score = 0
-    for i, q in enumerate(questions, start=1):
-        print(f"\nQuestion {i}: {q['question']}")
-        for letter, choice in zip(LETTERS, q["choices"]):
+    total = 20
+    for i in range(1, total + 1):
+        question, choices, answer = _generate_question(hard_mode)
+        letters = LETTERS[: len(choices)]
+        print(f"\nQuestion {i}: {question}")
+        for letter, choice in zip(letters, choices):
             print(f"  {letter}. {choice}")
         student = input("Votre réponse : ").strip().lower()
-        index = LETTERS.index(student) if student in LETTERS else -1
-        correct = q["answer"]
-        correct_text = q["choices"][correct]
-        if index == correct:
+        index = letters.index(student) if student in letters else -1
+        correct_text = choices[answer]
+        if index == answer:
             print("Exact ! ✅")
             score += 1
         else:
-            print(f"Non, la bonne réponse était {LETTERS[correct]}. {correct_text} ❌")
+            print(f"Non, la bonne réponse était {letters[answer]}. {correct_text} ❌")
 
-    total = len(questions)
     print(f"\nScore final : {score}/{total}")
+    log_result("math_tables_multiplication", score / total * 100)
 
 
 if __name__ == "__main__":
     main()
-

--- a/exercices/physique_changements_etats.py
+++ b/exercices/physique_changements_etats.py
@@ -1,6 +1,7 @@
 """Leçon et quiz sur les changements d'état de la matière."""
 
 from .utils import show_lesson
+from .logger import log_result
 
 
 GREEN = "\033[92m"
@@ -117,6 +118,7 @@ def main() -> None:
         print(f"{CYAN}Bravo ! Continue à réviser pour progresser encore. 👍{RESET}")
     else:
         print(f"{RED}Courage, relis la leçon et essaie à nouveau ! 💪{RESET}")
+    log_result("physique_changements_etats", score / total * 100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log each exercise run with timestamped score and utilities to read past scores
- record completion for hello world, history, physics and multiplication exercises
- expand multiplication quiz to 20 questions and adjust difficulty based on previous results

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68be804bccfc83238b7bf388ab96fa1c