### PR TITLE
Add geometry notation exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Le menu propose plusieurs exercices :
 - `hist_test` affiche `La préhistoire c'est ce qu'il y a avant l'histoire.`
 - `physique_changements_etats` propose une leçon et un quiz sur les changements d'état de la matière.
 - `math_tables_multiplication` propose une leçon et un quiz interactif pour pratiquer une table de multiplication.
+- `geometrie_notation` propose une leçon et un quiz sur les segments, droites et demi-droites.
 
 ## Exécuter
 

--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -5,6 +5,7 @@ from . import (
     hist_test,
     math_tables_multiplication,
     physique_changements_etats,
+    geometrie_notation,
 )
 
 EXERCICES = [
@@ -12,6 +13,7 @@ EXERCICES = [
     ("hist_test", hist_test.main),
     ("physique_changements_etats", physique_changements_etats.main),
     ("math_tables_multiplication", math_tables_multiplication.main),
+    ("geometrie_notation", geometrie_notation.main),
 ]
 
 

--- a/exercices/geometrie_notation.py
+++ b/exercices/geometrie_notation.py
@@ -1,0 +1,98 @@
+"""Leçon et quiz sur la notation des segments, droites et demi-droites."""
+
+from .utils import show_lesson
+from .logger import log_result
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+CYAN = "\033[96m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def main() -> None:
+    """Affiche la leçon puis un quiz sur les notations géométriques."""
+
+    lesson = f"""
+{CYAN}{BOLD}📏  Notation des segments, droites et demi-droites  📏{RESET}
+
+Un {BOLD}segment [AB]{RESET} relie deux points :
+*-------*
+A       B
+
+Une {BOLD}droite (AB){RESET} s'étend des deux côtés :
+----*-------*----
+    A       B
+
+Une {BOLD}demi-droite [AB){RESET} a une origine A et passe par B :
+*-------*-------
+A       B
+
+Exemple d'intersection :
+        C
+        *
+        |
+<---*---*---*--->
+    A   E   B
+        |
+        *
+        D
+        *--------->
+        F
+"""
+    show_lesson(lesson)
+
+    questions = [
+        {
+            "figure": """*-------*\nA       B""",
+            "choices": ["[AB]", "[AB)", "(AB]"],
+            "answer": 0,
+        },
+        {
+            "figure": """----*-------*----\n    A       B""",
+            "choices": ["(AB)", "[AB)", "[AB]"],
+            "answer": 0,
+        },
+        {
+            "figure": """*-------*-------\nA       B""",
+            "choices": ["[AB)", "(AB)", "(AB]"],
+            "answer": 0,
+        },
+        {
+            "figure": """---*-------*---\n   B       A""",
+            "choices": ["(BA)", "[BA)", "[BA]"],
+            "answer": 0,
+        },
+        {
+            "figure": """*-------*-------*\nA       B       C""",
+            "choices": ["[AC]", "(BC)", "[AB)"],
+            "answer": 0,
+        },
+    ]
+
+    print("Quiz : quelle est la bonne notation ?")
+    score = 0
+    for i, q in enumerate(questions, start=1):
+        print(f"\nQuestion {i} :")
+        print(q["figure"])
+        for j, choice in enumerate(q["choices"], start=1):
+            print(f"  {j}. {choice}")
+        try:
+            student = int(input("Votre réponse : ")) - 1
+        except ValueError:
+            student = -1
+        correct = q["answer"]
+        correct_text = q["choices"][correct]
+        if student == correct:
+            print(f"{GREEN}Exact ! ✅{RESET}")
+            score += 1
+        else:
+            print(f"{RED}Non, la bonne réponse était {correct + 1}. {correct_text} ❌{RESET}")
+
+    total = len(questions)
+    print(f"\n{BOLD}Score final : {score}/{total}{RESET}")
+    log_result("geometrie_notation", score / total * 100)
+
+
+if __name__ == "__main__":
+    main()

--- a/exercices/geometrie_notation.py
+++ b/exercices/geometrie_notation.py
@@ -2,6 +2,7 @@
 
 from .utils import show_lesson
 from .logger import log_result
+import random
 
 GREEN = "\033[92m"
 RED = "\033[91m"
@@ -94,6 +95,12 @@ Exemple d'intersection :
             "answer": 0,
         },
     ]
+
+    # Shuffle answer order for each question
+    for q in questions:
+        correct_choice = q["choices"][q["answer"]]
+        random.shuffle(q["choices"])
+        q["answer"] = q["choices"].index(correct_choice)
 
     print("Quiz : quelle est la bonne notation ?")
     score = 0

--- a/exercices/geometrie_notation.py
+++ b/exercices/geometrie_notation.py
@@ -17,55 +17,80 @@ def main() -> None:
 {CYAN}{BOLD}📏  Notation des segments, droites et demi-droites  📏{RESET}
 
 Un {BOLD}segment [AB]{RESET} relie deux points :
-*-------*
+x───────x
 A       B
 
 Une {BOLD}droite (AB){RESET} s'étend des deux côtés :
-----*-------*----
+───x───────x───
     A       B
 
 Une {BOLD}demi-droite [AB){RESET} a une origine A et passe par B :
-*-------*-------
+x───────x───────
 A       B
 
 Exemple d'intersection :
         C
-        *
-        |
-<---*---*---*--->
+        x
+        │
+<───x───x───x───>
     A   E   B
-        |
-        *
+        │
+        x
         D
-        *--------->
+        x────────>
         F
 """
     show_lesson(lesson)
 
     questions = [
         {
-            "figure": """*-------*\nA       B""",
+            "figure": """x───────x\nA       B""",
             "choices": ["[AB]", "[AB)", "(AB]"],
             "answer": 0,
         },
         {
-            "figure": """----*-------*----\n    A       B""",
+            "figure": """───x───────x───\n    A       B""",
             "choices": ["(AB)", "[AB)", "[AB]"],
             "answer": 0,
         },
         {
-            "figure": """*-------*-------\nA       B""",
+            "figure": """x───────x───────\nA       B""",
             "choices": ["[AB)", "(AB)", "(AB]"],
             "answer": 0,
         },
         {
-            "figure": """---*-------*---\n   B       A""",
+            "figure": """───x───────x───\n   B       A""",
             "choices": ["(BA)", "[BA)", "[BA]"],
             "answer": 0,
         },
         {
-            "figure": """*-------*-------*\nA       B       C""",
+            "figure": """x───────x───────x\nA       B       C""",
             "choices": ["[AC]", "(BC)", "[AB)"],
+            "answer": 0,
+        },
+        {
+            "figure": """x───────x───────\nB       A""",
+            "choices": ["[BA)", "(BA)", "(BA]"],
+            "answer": 0,
+        },
+        {
+            "figure": """───x───────x───\n   C       D""",
+            "choices": ["(CD)", "[CD]", "[CD)"],
+            "answer": 0,
+        },
+        {
+            "figure": """x───────x\nB       D""",
+            "choices": ["[BD]", "[BD)", "(BD)"],
+            "answer": 0,
+        },
+        {
+            "figure": """x A\n│\n│\nx────────────x────────\nB            C""",
+            "choices": ["[AB] et [BC)", "(AB) et (BC)", "(AB) et [BC)"],
+            "answer": 0,
+        },
+        {
+            "figure": """      x C\n      │\n◄─────x─────x─────►\n      B     D\n      │\n      x E""",
+            "choices": ["(BD) et [CE]", "[BD] et [CE)", "(BD) et (CE]"],
             "answer": 0,
         },
     ]


### PR DESCRIPTION
## Summary
- add geometry notation lesson and quiz
- expose geometrie_notation exercise in main menu and docs

## Testing
- `python -m exercices.geometrie_notation <<'EOF'
q
1
1
1
1
1
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68beec2d48708323ac653a10812a3773