### PR TITLE
Add software update option to main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Le menu propose plusieurs exercices :
 - `math_tables_multiplication` propose une leçon et un quiz interactif pour pratiquer une table de multiplication.
 - `geometrie_notation` propose une leçon et un quiz sur les segments, droites et demi-droites.
 
+Le menu propose également une option pour mettre à jour le logiciel ; elle exécute un `git pull` puis redémarre le programme.
+
 ## Exécuter
 
 ```bash

--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -1,5 +1,10 @@
 """Point d'entrée pour le programme exercices."""
 
+import os
+import sys
+import subprocess
+from pathlib import Path
+
 from . import (
     anglais_hello_world,
     hist_test,
@@ -17,16 +22,27 @@ EXERCICES = [
 ]
 
 
+def update_and_restart():
+    """Met à jour le dépôt via git pull puis redémarre le programme."""
+    repo_dir = Path(__file__).resolve().parent.parent
+    subprocess.run(["git", "pull"], cwd=repo_dir, check=False)
+    os.execv(sys.executable, [sys.executable] + sys.argv)
+
+
 def main():
     """Affiche un menu et lance l'exercice choisi."""
     while True:
         print("Choisissez un exercice :")
         for index, (name, _) in enumerate(EXERCICES, start=1):
             print(f"{index}. {name}")
+        print(f"{len(EXERCICES) + 1}. Mettre à jour le logiciel")
         print("0. Quitter")
         choice = input("Votre choix : ")
         if choice == "0":
             break
+        if choice == str(len(EXERCICES) + 1):
+            update_and_restart()
+            return
         try:
             index = int(choice) - 1
             _, func = EXERCICES[index]


### PR DESCRIPTION
## Summary
- allow updating the software from the menu by running a `git pull` and restarting
- document the new update option in the README

## Testing
- `python -m exercices <<'EOF'
0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68bfb389d79883238d3838c89d7ca533