### PR TITLE
feat: improve menu readability

### DIFF
--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -13,12 +13,15 @@ from . import (
     geometrie_notation,
 )
 
+# Les modules d'exercices sont listés ici pour apparaître dans le menu.
+# Chaque module définit sa propre chaîne ``DISPLAY_NAME`` utilisée pour
+# afficher un intitulé lisible par un humain.
 EXERCICES = [
-    ("anglais_hello_world", anglais_hello_world.main),
-    ("hist_test", hist_test.main),
-    ("physique_changements_etats", physique_changements_etats.main),
-    ("math_tables_multiplication", math_tables_multiplication.main),
-    ("geometrie_notation", geometrie_notation.main),
+    anglais_hello_world,
+    hist_test,
+    physique_changements_etats,
+    math_tables_multiplication,
+    geometrie_notation,
 ]
 
 
@@ -33,8 +36,8 @@ def main():
     """Affiche un menu et lance l'exercice choisi."""
     while True:
         print("Choisissez un exercice :")
-        for index, (name, _) in enumerate(EXERCICES, start=1):
-            print(f"{index}. {name}")
+        for index, module in enumerate(EXERCICES, start=1):
+            print(f"{index}. {module.DISPLAY_NAME}")
         print(f"{len(EXERCICES) + 1}. Mettre à jour le logiciel")
         print("0. Quitter")
         choice = input("Votre choix : ")
@@ -45,11 +48,11 @@ def main():
             return
         try:
             index = int(choice) - 1
-            _, func = EXERCICES[index]
+            module = EXERCICES[index]
         except (ValueError, IndexError):
             print("Choix invalide")
             continue
-        func()
+        module.main()
 
 
 if __name__ == "__main__":

--- a/exercices/anglais_hello_world.py
+++ b/exercices/anglais_hello_world.py
@@ -1,5 +1,8 @@
 """Module anglais_hello_world - affiche Hello World"""
 
+# Nom lisible de l'exercice pour le menu principal
+DISPLAY_NAME = "Anglais : Hello World"
+
 from .utils import scroll_text
 from .logger import log_result
 

--- a/exercices/geometrie_notation.py
+++ b/exercices/geometrie_notation.py
@@ -1,5 +1,8 @@
 """Leçon et quiz sur la notation des segments, droites et demi-droites."""
 
+# Nom lisible de l'exercice pour le menu principal
+DISPLAY_NAME = "Géométrie : Notations des segments et droites"
+
 from .utils import show_lesson
 from .logger import log_result
 import random

--- a/exercices/hist_test.py
+++ b/exercices/hist_test.py
@@ -1,3 +1,8 @@
+"""Petit exercice d'histoire"""
+
+# Nom lisible de l'exercice pour le menu principal
+DISPLAY_NAME = "Histoire : La préhistoire"
+
 from .utils import scroll_text
 from .logger import log_result
 

--- a/exercices/math_tables_multiplication.py
+++ b/exercices/math_tables_multiplication.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 """Tables de multiplication avec quiz interactif."""
 
+# Nom lisible de l'exercice pour le menu principal
+DISPLAY_NAME = "Maths : Tables de multiplication"
+
 import random
 
 from .logger import get_scores, log_result

--- a/exercices/physique_changements_etats.py
+++ b/exercices/physique_changements_etats.py
@@ -1,5 +1,8 @@
 """Leçon et quiz sur les changements d'état de la matière."""
 
+# Nom lisible de l'exercice pour le menu principal
+DISPLAY_NAME = "Physique : Changements d'état"
+
 from .utils import show_lesson
 from .logger import log_result
 


### PR DESCRIPTION
## Summary
- Add human-friendly `DISPLAY_NAME` to each exercise module
- Rework main menu to pull exercise titles from modules for better readability

## Testing
- `python -m exercices`

------
https://chatgpt.com/codex/tasks/task_e_68bfc25e3bec832399e139eefe3b7efe