### PR TITLE
Add origin matching quiz for English days

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Ce dépôt contient un programme `exercices` permettant d'exécuter différents 
 
 Le menu propose plusieurs exercices :
 - `anglais_hello_world` affiche `hello world!`
+- `anglais_jours_semaine` propose une leçon et un quiz pour apprendre les jours de la semaine en anglais et leurs origines mythologiques ou célestes.
 - `hist_test` affiche `La préhistoire c'est ce qu'il y a avant l'histoire.`
 - `physique_changements_etats` propose une leçon et un quiz sur les changements d'état de la matière.
 - `physique_proprietes_eau_liquide` propose une leçon et un quiz sur quelques propriétés de l'eau liquide.

--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from . import (
     anglais_hello_world,
+    anglais_jours_semaine,
     hist_test,
     physique_changements_etats,
     physique_proprietes_eau_liquide,
@@ -19,6 +20,7 @@ from . import (
 # afficher un intitulé lisible par un humain.
 EXERCICES = [
     anglais_hello_world,
+    anglais_jours_semaine,
     hist_test,
     physique_changements_etats,
     physique_proprietes_eau_liquide,

--- a/exercices/anglais_jours_semaine.py
+++ b/exercices/anglais_jours_semaine.py
@@ -1,0 +1,103 @@
+"""Leçon et quiz sur les jours de la semaine en anglais et leur origine."""
+
+# Nom lisible de l'exercice pour le menu principal
+DISPLAY_NAME = "Anglais : Jours de la semaine"
+
+import random
+
+from .utils import show_lesson
+from .logger import log_result
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+CYAN = "\033[96m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def main() -> None:
+    """Présente la leçon puis un quiz corrigé."""
+
+    lesson = f"""
+{CYAN}{BOLD}📚  Days of the Week Origins - Origines des jours  📚{RESET}
+
+Chaque jour anglais vient d'un astre ou d'un dieu :
+{BOLD}Monday{RESET} 🌙 → {BOLD}Moon day{RESET} (jour de la Lune)
+{BOLD}Tuesday{RESET} ⚔️ → {BOLD}Tiw's day{RESET} (dieu germanique de la guerre)
+{BOLD}Wednesday{RESET} 🧙 → {BOLD}Woden's day{RESET} (Odin, dieu de la sagesse)
+{BOLD}Thursday{RESET} 🔨 → {BOLD}Thor's day{RESET} (dieu du tonnerre)
+{BOLD}Friday{RESET} 💖 → {BOLD}Freya's day{RESET} (déesse de l'amour)
+{BOLD}Saturday{RESET} 🪐 → {BOLD}Saturn day{RESET} (dieu romain)
+{BOLD}Sunday{RESET} ☀️ → {BOLD}Sun day{RESET} (jour du Soleil)
+
+✨ {BOLD}Astuce mémotechnique{RESET} :
+Premières lettres → {BOLD}M T W T F S S{RESET}
+"{BOLD}Ma Tête Veut Toujours Faire Simple Souvent{RESET}"
+"""
+    show_lesson(lesson)
+
+    days = [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    ]
+
+    origins = {
+        "Monday": ("Moon", "linked with the Moon"),
+        "Tuesday": ("Tiw (Tyr)", "a Germanic god of war"),
+        "Wednesday": ("Woden (Odin)", "the god of wisdom"),
+        "Thursday": ("Thor", "the god of thunder"),
+        "Friday": ("Frigg/Freya", "the goddess of love"),
+        "Saturday": ("Saturn", "the Roman god"),
+        "Sunday": ("Sun", "linked with the Sun"),
+    }
+
+    print(f"{CYAN}{BOLD}✏️  Worksheet : relie chaque jour à son origine !  ✏️{RESET}")
+    print("Jours :")
+    for i, day in enumerate(days, start=1):
+        print(f"  {i}. {day}")
+
+    root_options = list(origins.values())
+    random.shuffle(root_options)
+    letter_map: dict[str, str] = {}
+    print("\nOrigines :")
+    for idx, (root, meaning) in enumerate(root_options):
+        letter = chr(ord("A") + idx)
+        letter_map[root] = letter
+        print(f"  {letter}. {root} - {meaning}")
+
+    print("\nIndique la lettre correspondant à chaque jour :")
+    score = 0
+    answers: dict[str, str] = {}
+    for day in days:
+        reply = input(f"{day} -> ").strip().upper()
+        answers[day] = reply
+        correct_letter = letter_map[origins[day][0]]
+        if reply == correct_letter:
+            print(f"{GREEN}Bien vu ! ✅{RESET}")
+            score += 1
+        else:
+            print(f"{RED}Oups ! ❌{RESET}")
+
+    total = len(days)
+    print(f"\n{BOLD}Corrections :{RESET}")
+    for day in days:
+        root, meaning = origins[day]
+        print(f"{day} → {root} : {meaning}")
+
+    print(f"\n{BOLD}Score final : {score}/{total}{RESET}")
+    if score == total:
+        print(f"{GREEN}Excellent ! Tu connais les origines par cœur ! 🥳{RESET}")
+    elif score >= total / 2:
+        print(f"{CYAN}Bravo ! Continue à pratiquer. 👍{RESET}")
+    else:
+        print(f"{RED}Relis la leçon et essaie encore ! 💪{RESET}")
+    log_result("anglais_jours_semaine", score / total * 100)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- teach mythological and celestial origins of English weekdays
- add matching-style worksheet to pair each day with its origin
- document the enriched lesson in the README

## Testing
- `python -m py_compile exercices/anglais_jours_semaine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c26b95c0048323862602a8184876eb