### PR TITLE
Document and install optional Windows requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,17 @@ Le menu propose plusieurs exercices :
 - `musique_cest_quoi` propose une leçon colorée et un quiz pour découvrir la portée, les notes et les rythmes.
 - `sciences_vivant_non_vivant` propose une leçon et un quiz pour classer les éléments en vivant, naturel non vivant ou fabriqué par l'humain.
 
-Le menu propose également une option pour mettre à jour le logiciel ; elle exécute un `git pull` puis redémarre le programme.
+Le menu propose également une option pour mettre à jour le logiciel. Elle exécute `git pull`, met à jour les dépendances Python, puis redémarre le programme.
+
+## Première installation
+
+Avant la première exécution, installez les dépendances optionnelles décrites dans `requirements.txt` :
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Sur Windows cette commande installe automatiquement `windows-curses`, nécessaire pour l'exercice interactif de musique.
 
 ## Exécuter
 

--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -38,9 +38,25 @@ EXERCICES = [
 
 
 def update_and_restart():
-    """Met à jour le dépôt via git pull puis redémarre le programme."""
+    """Met à jour le dépôt et ses dépendances, puis redémarre le programme."""
     repo_dir = Path(__file__).resolve().parent.parent
     subprocess.run(["git", "pull"], cwd=repo_dir, check=False)
+
+    requirements_file = repo_dir / "requirements.txt"
+    if requirements_file.exists():
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "-r",
+                str(requirements_file),
+            ],
+            check=False,
+        )
+
     os.execv(sys.executable, [sys.executable] + sys.argv)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+windows-curses; platform_system == "Windows"


### PR DESCRIPTION
## Summary
- add a requirements.txt documenting the optional windows dependency
- run pip install -r requirements.txt during the self-update routine
- document the first-time dependency installation step in the README

## Testing
- python -m compileall exercices

------
https://chatgpt.com/codex/tasks/task_e_68c90938deb083238707c87e66904c59