### PR TITLE
Ajoute des exercices sur les terminaisons du passé composé et du passé simple

### DIFF
--- a/exercices/__main__.py
+++ b/exercices/__main__.py
@@ -21,6 +21,8 @@ from . import (
     star_wars_quiz,
     sciences_vivant_non_vivant,
     francais_imparfait_passe_simple,
+    francais_passe_compose_terminaisons,
+    francais_passe_simple_terminaisons,
 )
 
 # Les modules d'exercices sont listés ici pour apparaître dans le menu.
@@ -42,6 +44,8 @@ EXERCICES = [
     star_wars_quiz,
     sciences_vivant_non_vivant,
     francais_imparfait_passe_simple,
+    francais_passe_compose_terminaisons,
+    francais_passe_simple_terminaisons,
 ]
 
 

--- a/exercices/francais_passe_compose_terminaisons.py
+++ b/exercices/francais_passe_compose_terminaisons.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+"""Révision des terminaisons du participe passé au passé composé."""
+
+DISPLAY_NAME = "Français : Passé composé – terminaisons"
+
+from .logger import log_result
+from .utils import show_lesson
+
+LESSON = """
+📚 **Rappel : former le passé composé**
+
+Le passé composé se construit avec un auxiliaire (**avoir** ou **être**) et un
+**participe passé**. C'est justement la terminaison de ce participe que tu vas
+réviser : tape uniquement la **fin du mot** (ex. `é`, `i`, `is`…), pas tout le
+mot.
+
+🧠 **Terminaisons principales selon le groupe**
+
+- **1er groupe** : les verbes en *-er* forment leur participe passé en **-é**.
+  > chanter → chanté, regarder → regardé
+- **2ᵉ groupe** : les verbes réguliers en *-ir* prennent **-i**.
+  > finir → fini, grandir → grandi
+- **3ᵉ groupe** : plusieurs modèles existent. Retenons ici quelques terminaisons
+  fréquentes :
+  - **-is / -it** (prendre → pris, faire → fait)
+  - **-u** (vendre → vendu, pouvoir → pu)
+
+Chaque question indique le groupe du verbe et la phrase à compléter. Tape la
+bonne terminaison pour obtenir le participe passé correct !
+"""
+
+QUESTIONS = [
+    {
+        "prompt": "Je raconte ma journée : j'ai racont__ ma journée.",
+        "ending": ["é", "e"],
+        "full_word": "raconté",
+        "group": "1er groupe",
+        "explanation": "Les verbes du 1er groupe prennent -é au participe passé.",
+    },
+    {
+        "prompt": "Tu as observé les oiseaux : tu as regard__ longtemps par la fenêtre.",
+        "ending": ["é", "e"],
+        "full_word": "regardé",
+        "group": "1er groupe",
+        "explanation": "Regarder appartient au 1er groupe : terminaison -é.",
+    },
+    {
+        "prompt": "Nous avons choisi un film : nous avons chois__ une comédie.",
+        "ending": ["i"],
+        "full_word": "choisi",
+        "group": "2ᵉ groupe",
+        "explanation": "Les verbes en -ir du 2ᵉ groupe prennent -i.",
+    },
+    {
+        "prompt": "Elles ont grandi vite : elles ont grand__ en une année.",
+        "ending": ["i"],
+        "full_word": "grandi",
+        "group": "2ᵉ groupe",
+        "explanation": "Grandir est un verbe régulier du 2ᵉ groupe → terminaison -i.",
+    },
+    {
+        "prompt": "Il a pris son sac : il a pr__ son sac avant de partir.",
+        "ending": ["is"],
+        "full_word": "pris",
+        "group": "3ᵉ groupe",
+        "explanation": "Prendre fait partie du 3ᵉ groupe : participe passé en -is.",
+    },
+    {
+        "prompt": "Elle a fait un dessin : elle a fa__ un beau paysage.",
+        "ending": ["it"],
+        "full_word": "fait",
+        "group": "3ᵉ groupe",
+        "explanation": "Faire (3ᵉ groupe) forme son participe passé en -it.",
+    },
+    {
+        "prompt": "Nous avons vendu nos vélos : nous avons vend__ le nôtre.",
+        "ending": ["u"],
+        "full_word": "vendu",
+        "group": "3ᵉ groupe",
+        "explanation": "Beaucoup de verbes du 3ᵉ groupe prennent -u (vendre → vendu).",
+    },
+    {
+        "prompt": "Vous avez pu finir : vous avez p__ terminer à temps !",
+        "ending": ["u"],
+        "full_word": "pu",
+        "group": "3ᵉ groupe",
+        "explanation": "Pouvoir est du 3ᵉ groupe et forme son participe passé en -u.",
+    },
+    {
+        "prompt": "Ils ont applaudi : ils ont applaud__ très fort.",
+        "ending": ["i"],
+        "full_word": "applaudi",
+        "group": "2ᵉ groupe",
+        "explanation": "Applaudir suit le modèle des verbes réguliers en -ir → -i.",
+    },
+    {
+        "prompt": "Tu as nettoyé ta chambre : tu as nettoy__ chaque étagère.",
+        "ending": ["é", "e"],
+        "full_word": "nettoyé",
+        "group": "1er groupe",
+        "explanation": "Nettoyer est un verbe du 1er groupe → terminaison -é.",
+    },
+]
+
+
+def main() -> None:
+    """Affiche la leçon puis lance le quiz sur les terminaisons du participe passé."""
+
+    show_lesson(LESSON)
+    print("Tape uniquement la terminaison demandée (par exemple `é`, `i`, `is`).")
+    score = 0
+    total = len(QUESTIONS)
+    for index, question in enumerate(QUESTIONS, start=1):
+        print(f"\nQuestion {index} – {question['group']}")
+        print(question["prompt"])
+        answer = input("Terminaison : ").strip().lower()
+        valid = [ending.lower() for ending in question["ending"]]
+        if answer in valid:
+            print("✅ Bravo !")
+            score += 1
+        else:
+            correct = question["ending"][0]
+            full_word = question["full_word"]
+            print(
+                f"❌ Ce n'est pas ça. Il fallait écrire `{correct}` pour obtenir `{full_word}`."
+            )
+            print(f"ℹ️ {question['explanation']}")
+    print(f"\nScore final : {score}/{total}")
+    percentage = score / total * 100 if total else 0.0
+    log_result("francais_passe_compose_terminaisons", percentage)
+
+
+if __name__ == "__main__":
+    main()

--- a/exercices/francais_passe_simple_terminaisons.py
+++ b/exercices/francais_passe_simple_terminaisons.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+"""Révision des terminaisons du passé simple selon les groupes."""
+
+DISPLAY_NAME = "Français : Passé simple – terminaisons"
+
+from .logger import log_result
+from .utils import show_lesson
+
+LESSON = """
+📚 **Rappel : conjuguer au passé simple**
+
+Le passé simple raconte des actions brèves dans les récits. Chaque groupe de
+verbes possède ses terminaisons propres. Dans ce quiz, tu dois taper uniquement
+la **terminaison** du verbe (ex. `ai`, `as`, `îmes`).
+
+🧠 **Terminaisons à connaître**
+
+- **1er groupe (-er)** : -ai, -as, -a, -âmes, -âtes, -èrent.
+- **2ᵉ groupe (-ir réguliers)** : -is, -is, -it, -îmes, -îtes, -irent.
+- **3ᵉ groupe** : plusieurs modèles.
+  - Modèle « prendre » : -is, -is, -it, -îmes, -îtes, -irent.
+  - Modèle « recevoir » : -us, -us, -ut, -ûmes, -ûtes, -urent.
+
+Les phrases indiquent toujours le groupe visé pour t'aider à repérer la bonne
+terminaison.
+"""
+
+QUESTIONS = [
+    {  # 1er groupe
+        "prompt": "Je (parler) longtemps avec ma sœur : je parl__ avec elle.",
+        "ending": ["ai"],
+        "full_word": "parlai",
+        "group": "1er groupe",
+        "explanation": "Au 1er groupe, la 1ʳᵉ personne du singulier se termine par -ai.",
+    },
+    {
+        "prompt": "Tu (regarder) les étoiles : tu regard__ le ciel.",
+        "ending": ["as"],
+        "full_word": "regardas",
+        "group": "1er groupe",
+        "explanation": "2ᵉ personne du singulier du 1er groupe → terminaison -as.",
+    },
+    {
+        "prompt": "Il (marcher) des heures : il march__ longtemps.",
+        "ending": ["a"],
+        "full_word": "marcha",
+        "group": "1er groupe",
+        "explanation": "3ᵉ personne du singulier au 1er groupe → terminaison -a.",
+    },
+    {
+        "prompt": "Nous (danser) sous la pluie : nous dans__ joyeusement.",
+        "ending": ["âmes", "ames"],
+        "full_word": "dansâmes",
+        "group": "1er groupe",
+        "explanation": "1ʳᵉ personne du pluriel du 1er groupe → -âmes.",
+    },
+    {
+        "prompt": "Vous (chanter) en chœur : vous chant__ ensemble.",
+        "ending": ["âtes", "ates"],
+        "full_word": "chantâtes",
+        "group": "1er groupe",
+        "explanation": "2ᵉ personne du pluriel du 1er groupe → -âtes.",
+    },
+    {
+        "prompt": "Ils (jouer) au ballon : ils jou__ tout l'après-midi.",
+        "ending": ["èrent", "erent"],
+        "full_word": "jouèrent",
+        "group": "1er groupe",
+        "explanation": "3ᵉ personne du pluriel du 1er groupe → -èrent.",
+    },
+    {  # 2e groupe
+        "prompt": "Je (finir) mes devoirs : je fin__ tout rapidement.",
+        "ending": ["is"],
+        "full_word": "finis",
+        "group": "2ᵉ groupe",
+        "explanation": "Je finis : terminaison -is pour les verbes réguliers en -ir.",
+    },
+    {
+        "prompt": "Tu (choisir) un livre : tu chois__ ce roman.",
+        "ending": ["is"],
+        "full_word": "choisis",
+        "group": "2ᵉ groupe",
+        "explanation": "Tu choisis : même terminaison -is.",
+    },
+    {
+        "prompt": "Elle (grandir) très vite : elle grand__ en un été.",
+        "ending": ["it"],
+        "full_word": "grandit",
+        "group": "2ᵉ groupe",
+        "explanation": "Il/elle/on grandit : terminaison -it.",
+    },
+    {
+        "prompt": "Nous (rougir) de timidité : nous roug__ un peu.",
+        "ending": ["îmes", "imes"],
+        "full_word": "rougîmes",
+        "group": "2ᵉ groupe",
+        "explanation": "Nous rougîmes : terminaison -îmes (accent obligatoire à l'écrit).",
+    },
+    {
+        "prompt": "Vous (réfléchir) calmement : vous réfléch__ avant d'agir.",
+        "ending": ["îtes", "ites"],
+        "full_word": "réfléchîtes",
+        "group": "2ᵉ groupe",
+        "explanation": "Vous réfléchîtes : terminaison -îtes.",
+    },
+    {
+        "prompt": "Ils (réussir) leur examen : ils réuss__ tous !",
+        "ending": ["irent"],
+        "full_word": "réussirent",
+        "group": "2ᵉ groupe",
+        "explanation": "Ils réussirent : terminaison -irent au 2ᵉ groupe.",
+    },
+    {  # 3e groupe - modèle prendre
+        "prompt": "Je (prendre) un croissant : je pr__ un croissant croustillant.",
+        "ending": ["is"],
+        "full_word": "pris",
+        "group": "3ᵉ groupe",
+        "explanation": "Je pris : terminaison -is pour ce modèle du 3ᵉ groupe.",
+    },
+    {
+        "prompt": "Tu (écrire) une lettre : tu écriv__ à ton amie.",
+        "ending": ["is"],
+        "full_word": "écrivis",
+        "group": "3ᵉ groupe",
+        "explanation": "Écrire suit la série en -is/-is/-it au passé simple.",
+    },
+    {
+        "prompt": "Il (dire) la vérité : il d__ tout ce qu'il savait.",
+        "ending": ["it"],
+        "full_word": "dit",
+        "group": "3ᵉ groupe",
+        "explanation": "Il dit : terminaison -it comme beaucoup de verbes du 3ᵉ groupe.",
+    },
+    {
+        "prompt": "Nous (venir) en aide : nous vîn__ immédiatement.",
+        "ending": ["mes"],
+        "full_word": "vînmes",
+        "group": "3ᵉ groupe",
+        "explanation": "Venir est irrégulier : nous vînmes (terminaison -mes).",
+    },
+    {
+        "prompt": "Vous (recevoir) les consignes : vous reç__ toutes les instructions.",
+        "ending": ["ûtes", "utes"],
+        "full_word": "reçûtes",
+        "group": "3ᵉ groupe",
+        "explanation": "Recevoir suit le modèle en -us/-ut/-ûtes.",
+    },
+    {
+        "prompt": "Ils (pouvoir) rentrer : ils pur__ enfin chez eux.",
+        "ending": ["ent"],
+        "full_word": "purent",
+        "group": "3ᵉ groupe",
+        "explanation": "Pouvoir → ils purent : terminaison -ent pour ce modèle.",
+    },
+]
+
+
+def main() -> None:
+    """Affiche la leçon puis lance le quiz sur le passé simple."""
+
+    show_lesson(LESSON)
+    print("Tape seulement la terminaison demandée (ex. `ai`, `is`, `ûtes`).")
+    score = 0
+    total = len(QUESTIONS)
+    for index, question in enumerate(QUESTIONS, start=1):
+        print(f"\nQuestion {index} – {question['group']}")
+        print(question["prompt"])
+        answer = input("Terminaison : ").strip().lower()
+        valid = [ending.lower() for ending in question["ending"]]
+        if answer in valid:
+            print("✅ Bien joué !")
+            score += 1
+        else:
+            correct = question["ending"][0]
+            full_word = question["full_word"]
+            print(
+                f"❌ Mauvaise terminaison. Il fallait écrire `{correct}` pour obtenir `{full_word}`."
+            )
+            print(f"ℹ️ {question['explanation']}")
+    print(f"\nScore final : {score}/{total}")
+    percentage = score / total * 100 if total else 0.0
+    log_result("francais_passe_simple_terminaisons", percentage)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ajoute un quiz sur les terminaisons du participe passé au passé composé en insistant sur les trois groupes
- ajoute un quiz de passé simple où l'élève ne saisit que la terminaison correcte
- enregistre les deux nouveaux modules dans le menu principal

## Testing
- python -m compileall exercices

------
https://chatgpt.com/codex/tasks/task_e_68dea6a85e58832397e41a9b5b985c2b